### PR TITLE
修复参数值为空bug

### DIFF
--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostFormRequest.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostFormRequest.java
@@ -115,7 +115,10 @@ public class PostFormRequest extends OkHttpRequest
 
         for (String key : params.keySet())
         {
-            builder.add(key, params.get(key));
+            //接口参数可传可不传时
+            if (params.get(key)!=null){
+                builder.add(key, params.get(key));
+            }
         }
     }
 }


### PR DESCRIPTION
//这样就不需要判断type值
 /**
     \* 获取预约挂号和体检预约的医院信息列表
     \* @param type 不传 表示获取推荐医院，0表示获取推荐体检中心
     \* @param city 城市名
     \* @param objectCallBack
     */
public void getRecommendedHospital(String type, String city, ObjectCallBack objectCallBack){
String url= ConstantValue.SERVER_URL+ConstantValue.V_DEPARTMENT_SORT;
OkHttpUtils.post()
.url(url)
.addParams("v_department_mold_id",type)
.addParams("city",city)
.build()
.execute(objectCallBack);
}
