### PR TITLE
fix GET request url build error

### DIFF
--- a/okhttputils/src/main/java/com/zhy/http/okhttp/builder/GetBuilder.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/builder/GetBuilder.java
@@ -1,5 +1,7 @@
 package com.zhy.http.okhttp.builder;
 
+import android.net.Uri;
+
 import com.zhy.http.okhttp.request.GetRequest;
 import com.zhy.http.okhttp.request.RequestCall;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/builder/GetBuilder.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/builder/GetBuilder.java
@@ -24,18 +24,19 @@ public class GetBuilder extends OkHttpRequestBuilder implements HasParamsable
 
     protected String appendParams(String url, Map<String, String> params)
     {
-        StringBuilder sb = new StringBuilder();
-        sb.append(url + "?");
-        if (params != null && !params.isEmpty())
+       if (url == null || params == null || params.isEmpty())
+       {
+            return url;
+       }
+        Uri.Builder builder = Uri.parse(url).buildUpon();
+        Set<String> keys = params.keySet();
+        Iterator<String> iterator = keys.iterator();
+        while (iterator.hasNext())
         {
-            for (String key : params.keySet())
-            {
-                sb.append(key).append("=").append(params.get(key)).append("&");
-            }
+            String key = iterator.next();
+            builder.appendQueryParameter(key, params.get(key));
         }
-
-        sb = sb.deleteCharAt(sb.length() - 1);
-        return sb.toString();
+        return builder.build().toString();
     }
 
     @Override


### PR DESCRIPTION
例如一个GET请求调用如下:
``` java
OkHttpUtils
                .get()
                .url("https://www.v2ex.com/api/nodes/show.json?user=1")
                .addParams("name", "python")
                .build()
                .execute(new StringCallback() {
                    @Override
                    public void onError(Call call, Exception e) {
                        L.e(e.getMessage());
                    }

                    @Override
                    public void onResponse(String response) {
                        L.e(response);
                    }
                });
```
最终发起的HTTP请求链接为: `https://www.v2ex.com/api/nodes/show.json?user=1?name=python`
不应该是`https://www.v2ex.com/api/nodes/show.json?user=1&name=python`嘛?