### PR TITLE
修复原有单例模式的线程不安全

### DIFF
--- a/okhttputils/src/main/java/com/zhy/http/okhttp/OkHttpUtils.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/OkHttpUtils.java
@@ -23,7 +23,7 @@ import okhttp3.Response;
 public class OkHttpUtils
 {
     public static final long DEFAULT_MILLISECONDS = 10_000L;
-    private static OkHttpUtils mInstance;
+    private volatile static OkHttpUtils mInstance;
     private OkHttpClient mOkHttpClient;
     private Platform mPlatform;
 


### PR DESCRIPTION
在原有程序中,instance = new Singleton();
其并不是原子的,会做三件事情,
1.给 instance 分配内存
2.调用 Singleton 的构造函数来初始化成员变量
3.将instance对象指向分配的内存空间（执行完这步 instance 就为非 null 了）
步骤2和3可能会重排序,执行顺序可能为1->3->2,这样的话就无法保证第一个线程执行到3, instance不为空, 此时第二个线程执行到initClient函数里的第一个检查null处, 此时instance不为空, 将会直接返回, 从而报错. 所以需要使用volatile来禁止重排序.