### PR TITLE
完善泛型序列化Callback不能返回array，细化并简化了回调接口、支持返回String、User、List<User>等等，再增加一个基类处理方法

### DIFF
--- a/XHttpCallBack.java
+++ b/XHttpCallBack.java
@@ -19,6 +19,12 @@ public abstract class XHttpCallBack<T> extends Callback<T> {
     @Override
     public T parseNetworkResponse(Response response, int id) throws Exception {
         String result = response.body().string();
+        try {
+            result = unBunding(result);
+        }catch (Exception e){
+            onParser(e, id);
+            return null;
+        }
         if (getClass().getGenericSuperclass() == XHttpCallBack.class){
             return (T)result;// 默认返回String
         }
@@ -37,6 +43,7 @@ public abstract class XHttpCallBack<T> extends Callback<T> {
 
     @Override
     public void onResponse(T response, int id) {
+        //if (response != null)
         onSuccess(response, id);
     }
 
@@ -49,5 +56,25 @@ public abstract class XHttpCallBack<T> extends Callback<T> {
         System.out.println("数据解析错误，统一处理"+e);
     }
 
+    public String unBunding(String json) throws JSONException {
+        // 很多情况下返回的json是这种格式的, 统一处理
+        // 这里只适用于处理获取一个返回Json串，如果要同时获取多个data1、data2...，建议直接Entity返回
+//        {
+//            "code": 0,
+//            "msg": "上传成功",
+//            "data": [
+//                  {
+//                      "id": 1,
+//                      "name": "huangxy"
+//                  }
+//            ]
+//        }
+//        //JSONArray array = new JSONArray(json);
+//        JSONObject obj = new JSONObject(json);
+//        return obj.getString("data");
+        return json;
+    }
+
     public abstract void onSuccess(T result, int id);
+    
 }

--- a/XHttpCallBack.java
+++ b/XHttpCallBack.java
@@ -22,6 +22,9 @@ public abstract class XHttpCallBack<T> extends Callback<T> {
         if (getClass().getGenericSuperclass() == XHttpCallBack.class){
             return (T)result;// 默认返回String
         }
+        if(((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0] == String.class){
+            return (T)result;// 返回String类型
+        }
         // 这句重点，同时支持T、List<T>等等
         Type type = $Gson$Types.canonicalize(((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0]);
         try {

--- a/XHttpCallBack.java
+++ b/XHttpCallBack.java
@@ -1,0 +1,49 @@
+package com.administrator.ticat.AsyncTask;
+
+import com.google.gson.Gson;
+import com.google.gson.internal.$Gson$Types;
+import com.zhy.http.okhttp.callback.Callback;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import okhttp3.Call;
+import okhttp3.Response;
+
+/**
+ * Created by Git@Smark on 2016/7/17.
+ * 简化接口，支持返回String、Entity、List<Entity>
+ */
+public abstract class XHttpCallBack<T> extends Callback<T> {
+
+    @Override
+    public T parseNetworkResponse(Response response, int id) throws Exception {
+        String result = response.body().string();
+        if (getClass().getGenericSuperclass() == XHttpCallBack.class){
+            return (T)result;// 默认返回String
+        }
+        Type type = $Gson$Types.canonicalize(((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0]);
+        try {
+            return new Gson().fromJson(result, type);
+        }catch (Exception e){
+            onParser(e, id);
+        }
+        return null;
+    }
+
+    @Override
+    public void onResponse(T response, int id) {
+        onSuccess(response, id);
+    }
+
+    @Override
+    public void onError(Call call, Exception e, int id) {
+        System.out.println("网络请求错误，统一处理"+e);
+    }
+
+    public void onParser(Exception e, int id){
+        System.out.println("数据解析错误，统一处理"+e);
+    }
+
+    public abstract void onSuccess(T result, int id);
+}

--- a/XHttpCallBack.java
+++ b/XHttpCallBack.java
@@ -1,4 +1,4 @@
-package com.administrator.ticat.AsyncTask;
+package com.huangxy.XhttpUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.internal.$Gson$Types;
@@ -22,6 +22,7 @@ public abstract class XHttpCallBack<T> extends Callback<T> {
         if (getClass().getGenericSuperclass() == XHttpCallBack.class){
             return (T)result;// 默认返回String
         }
+        // 这句重点，同时支持T、List<T>等等
         Type type = $Gson$Types.canonicalize(((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0]);
         try {
             return new Gson().fromJson(result, type);

--- a/XHttpUtilsDemo.java
+++ b/XHttpUtilsDemo.java
@@ -1,0 +1,64 @@
+package com.administrator.ticat.AsyncTask;
+
+import com.administrator.ticat.Entity.User;
+import com.zhy.http.okhttp.OkHttpUtils;
+
+import java.util.List;
+
+/**
+ * Created by Git@Smark on 2016/7/17.
+ */
+public class XHttpUtilsDemo {
+
+    public XHttpUtilsDemo(){
+
+        String url = "https://github.com/GitSmark";
+
+        OkHttpUtils
+                .get()
+                .url(url)
+                .addParams("param1", "value")
+                .addParams("param2", "value")
+                .build()
+                .execute(new XHttpCallBack() {
+
+                    @Override
+                    public void onSuccess(Object result, int id) {
+                        //Success
+                    }
+                });
+
+        OkHttpUtils
+                .post()
+                .url(url)
+                .addParams("param1", "value")
+                .addParams("param2", "value")
+                .build()
+                .execute(new XHttpCallBack<User>() {
+
+                    @Override
+                    public void onSuccess(User result, int id) {
+                        //Success
+                    }
+                });
+
+        OkHttpUtils
+                .post()
+                .url(url)
+                .addParams("param1", "value")
+                .addParams("param2", "value")
+                .build()
+                .execute(new XHttpCallBack<List<User>>() {
+
+                    @Override
+                    public void onSuccess(List<User> result, int id) {
+                        //Success
+                    }
+
+                    //@Override
+                    //public void onParser(Exception e, int id) {
+                    //   super.onParser(e, id);
+                    //}
+                });
+    }
+}

--- a/XHttpUtilsDemo.java
+++ b/XHttpUtilsDemo.java
@@ -1,4 +1,4 @@
-package com.administrator.ticat.AsyncTask;
+package com.huangxy.XhttpUtils;
 
 import com.administrator.ticat.Entity.User;
 import com.zhy.http.okhttp.OkHttpUtils;


### PR DESCRIPTION
完善泛型序列化Callback不能返回array，细化并简化了回调接口、支持返回String、User、List\<User\>等等