### PR TITLE
新增泛型序列化回调接口XHttpCallBack，简化了接口、支持返回String、Array、Entity、List<T>、BaseEntity<T>等等，再增加一个基类处理方法

### DIFF
--- a/okhttputils/src/main/java/com/zhy/http/okhttp/callback/XHttpCallBack.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/callback/XHttpCallBack.java
@@ -1,0 +1,70 @@
+package com.zhy.http.okhttp.callback;
+
+import com.google.gson.Gson;
+import com.google.gson.internal.$Gson$Types;
+import com.zhy.http.okhttp.callback.Callback;
+
+import org.json.JSONException;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import okhttp3.Call;
+import okhttp3.Response;
+
+/**
+ * Created by Git@Smark on 2016/7/17.
+ * 简化接口，支持返回String、Array、Entity、List<T>、BaseEntity<T>等等
+ */
+public abstract class XHttpCallBack<T> extends Callback<T> {
+
+    @Override
+    public T parseNetworkResponse(Response response, int id) throws Exception {
+        String result = response.body().string();
+        try {
+            result = unBunding(result);
+        }catch (Exception e){
+            onParser(e, id);
+            return null;
+        }
+        if (getClass().getGenericSuperclass() == XHttpCallBack.class){
+            return (T)result;// 默认返回String
+        }
+        if(((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0] == String.class){
+            return (T)result;// String类型直接返回
+        }
+        try {
+            Type type = $Gson$Types.canonicalize(((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0]);
+            return new Gson().fromJson(result, type);
+        }catch (Exception e){
+            onParser(e, id);
+        }
+        return null;
+    }
+
+    @Override
+    public void onResponse(T response, int id) {
+        if (response != null) onSuccess(response, id);
+    }
+
+    public void onParser(Exception e, int id){// 数据解析错误，统一处理
+        e.printStackTrace();
+    }
+
+    @Override
+    public void onError(Call call, Exception e, int id) {// 网络请求错误，统一处理
+        e.printStackTrace();
+    }
+
+    public String unBunding(String json) throws JSONException {
+        // 很多情况下返回的json是这种格式的:{"code": 0,"msg": "success","data": [{"username": "huangxy","password": "123456",...}]}, 统一处理
+        // 这里只适用于处理获取一个返回Json串，如果不需要统一处理建议定义一个泛型基类直接返回，参考BaseEntity<T>
+        // 如果要同时获取多个data1、data2...，建议直接Entity返回
+        // JSONArray array = new JSONArray(json);
+        // JSONObject obj = new JSONObject(json);
+        // return obj.getString("data");
+        return json;
+    }
+
+    public abstract void onSuccess(T result, int id);
+}

--- a/sample-okhttp/src/main/java/com/zhy/sample_okhttp/BaseEntity.java
+++ b/sample-okhttp/src/main/java/com/zhy/sample_okhttp/BaseEntity.java
@@ -1,0 +1,10 @@
+package com.zhy.sample_okhttp;
+
+/**
+ * Created by Git@Smark on 2016/7/21.
+ */
+public class BaseEntity<T> {
+    public int Code;
+    public String msg;
+    public T data;
+}

--- a/sample-okhttp/src/main/java/com/zhy/sample_okhttp/MainActivity.java
+++ b/sample-okhttp/src/main/java/com/zhy/sample_okhttp/MainActivity.java
@@ -17,6 +17,7 @@ import com.zhy.http.okhttp.callback.BitmapCallback;
 import com.zhy.http.okhttp.callback.FileCallBack;
 import com.zhy.http.okhttp.callback.GenericsCallback;
 import com.zhy.http.okhttp.callback.StringCallback;
+import com.zhy.http.okhttp.callback.XHttpCallBack;
 import com.zhy.http.okhttp.cookie.CookieJarImpl;
 
 import java.io.File;
@@ -199,7 +200,92 @@ public class MainActivity extends AppCompatActivity
                     }
                 });
     }
+    
+    public XHttpUtilsDemo()
+    { 
+        String url = "https://github.com/GitSmark";
 
+        OkHttpUtils
+            .get()
+            .url(url)
+            .addParams("param1", "value")
+            .addParams("param2", "value")
+            .build()
+            .execute(new XHttpCallBack() {
+
+                @Override
+                public void onSuccess(Object result, int id) {
+                    //Success
+                }
+            });
+
+        OkHttpUtils
+            .post()
+            .url(url)
+            .addParams("param1", "value")
+            .addParams("param2", "value")
+            .build()
+            .execute(new XHttpCallBack<User>() {
+
+                @Override
+                public void onSuccess(User result, int id) {
+                    //Success
+                }
+            });
+
+        OkHttpUtils
+            .post()
+            .url(url)
+            .addParams("param1", "value")
+            .addParams("param2", "value")
+            .build()
+            .execute(new XHttpCallBack<List<User>>() {
+
+                @Override
+                public void onSuccess(List<User> result, int id) {
+                    //Success
+                }
+
+                //@Override
+                //public void onParser(Exception e, int id) {
+                //   super.onParser(e, id);
+                //}
+            });
+
+        OkHttpUtils
+            .post()
+            .url(url)
+            .addParams("param1", "value")
+            .addParams("param2", "value")
+            .build()
+            .execute(new XHttpCallBack<BaseEntity<List<User>>>() {
+
+                @Override
+                public void onSuccess(BaseEntity<List<User>> result, int id) {
+                    //Success
+                }
+            });
+
+        OkHttpUtils
+            .post()
+            .url(url)
+            .addParams("param1", "value")
+            .addParams("param2", "value")
+            .build()
+            .execute(new XHttpCallBack<List<User>>() {
+
+                @Override
+                public String unBunding(String json) throws JSONException {
+                    JSONObject obj = new JSONObject(json);
+                    return obj.getString("data");
+                }
+
+                @Override
+                public void onSuccess(List<User> result, int id) {
+                    //Success
+                }
+            });
+    }
 
     public void getHttpsHtml(View view)
     {


### PR DESCRIPTION
新增泛型序列化回调接口XHttpCallBack，简化了接口、支持返回String、Array、Entity、List\<T\>、BaseEntity\<T\>等等，再增加一个基类处理方法，Sample里有使用示例。